### PR TITLE
Use page.goto instead of page.setContent to wait for page to load all resources

### DIFF
--- a/src/convertHTMLToPDF.js
+++ b/src/convertHTMLToPDF.js
@@ -6,7 +6,7 @@ let convertHTMLToPDF = async (html, callback, options = null) => {
     if (!options) {
         options = { format: 'Letter' };
     }
-    await page.setContent(html);
+    await page.goto(`data:text/html,${html}`, { waitUntil: 'networkidle0' });
     await page.pdf(options).then(callback, function(error) {
         console.log(error);
     });


### PR DESCRIPTION
Use `page.setContent` can render blank pdf when `html` contains external resources.

See: https://github.com/GoogleChrome/puppeteer/issues/728